### PR TITLE
Stitchenvs

### DIFF
--- a/gym_minigrid/envs/__init__.py
+++ b/gym_minigrid/envs/__init__.py
@@ -24,3 +24,4 @@ from gym_minigrid.envs.distshift import *
 from gym_minigrid.envs.doorkeyoptional import *
 from gym_minigrid.envs.opengifts import *
 from gym_minigrid.envs.fetchkey import *
+from gym_minigrid.envs.key_to_gifts_to_door import *

--- a/gym_minigrid/envs/doorkeyoptional.py
+++ b/gym_minigrid/envs/doorkeyoptional.py
@@ -4,19 +4,21 @@ from gym_minigrid.register import register
 
 class DoorKeyOptionalEnv(MiniGridEnv):
     """
-    Environment with a yellow door and no key, sparse reward
+    Environment with a yellow door and no key, sparse reward.  Agent
+    must unlock door to reach goal.
 
     Agent cannot solve task unless it is already carrying a yellow key 
     when the environment is initialized.
     """
 
-    def __init__(self, size=8, key_color=None, door_color='yellow'):
+    def __init__(self,
+                 size=8,
+                 key_color=None,
+                 door_color='yellow',
+                 max_steps=10*8**2):
         self._key_color = key_color  # must be same as door_color to solve task
         self._door_color = door_color
-        super().__init__(
-            grid_size=size,
-            max_steps=10*size*size
-        )
+        super().__init__(grid_size=size, max_steps=max_steps)
 
     def reset(self):
         """Override reset so that agent can be initialized

--- a/gym_minigrid/envs/fetchkey.py
+++ b/gym_minigrid/envs/fetchkey.py
@@ -9,13 +9,17 @@ class KeyEnv(MiniGridEnv):
     either case.
     """
 
-    def __init__(self, size=8, key_color='yellow', start_by_key=False):
+    def __init__(self,
+                 size=8,
+                 key_color='yellow',
+                 start_by_key=False,
+                 max_steps=2*8**2):
         self.key_color = key_color
         self._start_by_key = start_by_key
 
         super().__init__(
             grid_size=size,
-            max_steps=2*size**2,
+            max_steps=max_steps,
             # Set this to True for maximum speed
             see_through_walls=True,
         )

--- a/gym_minigrid/envs/key_to_gifts_to_door.py
+++ b/gym_minigrid/envs/key_to_gifts_to_door.py
@@ -1,0 +1,77 @@
+import gym
+from gym_minigrid.register import register
+
+from gym_minigrid.envs.fetchkey import KeyEnv
+from gym_minigrid.envs.opengifts import GiftsEnv
+from gym_minigrid.envs.doorkeyoptional import DoorKeyOptionalEnv
+
+
+class KeyToGiftsToDoorKeyOptional(gym.Wrapper):
+    """
+    Stitches together three environments: 
+    (1) KeyEnv 
+    (2) GiftsEnv
+    (3) DoorKeyOptionalEnv
+
+    Agent is teleported from (1) to (2) to (3).  The agent is initialized with or
+    without the key in (3), depending on whether it successfully fetched it in (1).
+    """
+    def __init__(self, key_kwargs, gifts_kwargs, doorkeyoptional_kwargs):
+        self._envs = [KeyEnv, GiftsEnv, DoorKeyOptionalEnv]
+        self._env_kwargs = [key_kwargs, gifts_kwargs, doorkeyoptional_kwargs]
+        self.num_phases = len(self._envs)
+        self._env_idx = None  # index of the current env
+        self.env = KeyEnv(**key_kwargs)
+        super().__init__(self.env)
+
+
+    def reset(self):
+        """reset returns agent back to first environment, KeyEnv"""
+        self._env_idx = 0
+        self.env = self._envs[self._env_idx](**self._env_kwargs[self._env_idx])
+        observation = self.env.reset()
+        return observation
+
+    def step(self, action):
+        observation, reward, done, info = self.env.step(action)
+        if done is True and self._env_idx < self.num_phases - 1:
+            if self._env_idx == 0:
+                # if agent fetched key in first environment, initialize it with a key
+                # in the last environment
+                self._env_kwargs[2]['key_color'] = info.get('carrying_key_color')
+
+            # teleport to the next environment
+            self._env_idx += 1
+            self.env = self._envs[self._env_idx](**self._env_kwargs[self._env_idx])
+            observation, reward, done, info = self.env.reset(), 0, False, {}
+
+        return observation, reward, done, info
+
+
+class TinyKeyGiftsDoorEnv(KeyToGiftsToDoorKeyOptional):
+    def __init__(self):
+        key_kwargs = dict(
+            size=6,
+            key_color='yellow',
+            start_by_key=False,
+            max_steps=10
+        )
+        gifts_kwargs = dict(
+            size=6,
+            num_objs=3,
+            gift_reward=1,
+            max_steps=5*6**2
+        )
+        doorkeyoptional_kwargs = dict(
+            size=8,
+            key_color=None,
+            door_color='yellow',
+            max_steps=30
+        )
+        super().__init__(key_kwargs, gifts_kwargs, doorkeyoptional_kwargs)
+
+
+register(
+    id='MiniGrid-KeyDoorGifts-tiny-v0',
+    entry_point='gym_minigrid.envs:TinyKeyGiftsDoorEnv'
+)

--- a/gym_minigrid/envs/opengifts.py
+++ b/gym_minigrid/envs/opengifts.py
@@ -8,7 +8,11 @@ class GiftsEnv(MiniGridEnv):
     placed gifts
     """
 
-    def __init__(self, size=8, num_objs=3, gift_reward=10):
+    def __init__(self,
+                 size=8,
+                 num_objs=3,
+                 gift_reward=10,
+                 max_steps=5*8**2):
         self._gift_reward = gift_reward  # TODO: draw this from a Gaussian
         if num_objs < 1:
             raise ValueError(f"num_objs must be an integer greater than 0")
@@ -17,7 +21,7 @@ class GiftsEnv(MiniGridEnv):
 
         super().__init__(
             grid_size=size,
-            max_steps=5*size**2,
+            max_steps=5*max_steps,
             # Set this to True for maximum speed
             see_through_walls=True
         )


### PR DESCRIPTION
Create Wrapper that stitches together 3 environments (an env with just a key, an env with distractor gifts, and a final env with a door and goal behind the door, but not key).  If the agent picks up a key in the first environment, it will be initialized with it in the 3rd (but not the distractor phase).

TODO: consider either overriding `_reward` in DoorKeyOptionalEnv or using https://github.com/openai/gym/blob/master/gym/wrappers/transform_reward.py wrapper to scale the final goal reward relative to the size of the gift rewards.