### PR TITLE
Rewardtransition

### DIFF
--- a/gym_minigrid/envs/key_to_gifts_to_door.py
+++ b/gym_minigrid/envs/key_to_gifts_to_door.py
@@ -61,7 +61,7 @@ class KeyToGiftsToDoorKeyOptional(gym.Env):
                 **self._env_kwargs[self._env_idx],
                 seed=self._wrapper_seed
             )
-            observation, reward, done, info = self.env.reset(), 0, False, {}
+            observation, done, info = self.env.reset(), False, {}
 
         return observation, reward, done, info
 

--- a/gym_minigrid/envs/key_to_gifts_to_door.py
+++ b/gym_minigrid/envs/key_to_gifts_to_door.py
@@ -54,6 +54,8 @@ class KeyToGiftsToDoorKeyOptional(gym.Env):
                 # if agent fetched key in first environment, initialize it with a key
                 # in the last environment
                 self._env_kwargs[-1]['key_color'] = info.get('carrying_key_color')
+                if info.get('carrying_key_color') is not None:
+                    print("Agent picked up key!")
 
             # teleport to the next environment
             self._env_idx += 1
@@ -86,7 +88,7 @@ class TinyKeyGiftsDoorEnv(KeyToGiftsToDoorKeyOptional):
             size=6,
             key_color='yellow',
             start_by_key=False,
-            max_steps=10
+            max_steps=6**2
         )
         gifts_kwargs = dict(
             size=6,
@@ -98,7 +100,7 @@ class TinyKeyGiftsDoorEnv(KeyToGiftsToDoorKeyOptional):
             size=8,
             key_color=None,
             door_color='yellow',
-            max_steps=30
+            max_steps=8**2
         )
         super().__init__(key_kwargs, gifts_kwargs, doorkeyoptional_kwargs)
 


### PR DESCRIPTION
Bugfix -- was zeroing out reward from last step in env before transition, fix so the reward is passed through when agent lands in new env with new obs.

- also increase number of max steps before timeout in `TinyKeyGiftsDoorEnv` so the env can be more practically used for training  (agent has chance to explore more).  TODO: consider increasing max steps even more.  For now, a2c with memory takes about 1.2 million training frames to learn in the env.