### PR TITLE
Prepenv

### DIFF
--- a/gym_minigrid/envs/doorkeyoptional.py
+++ b/gym_minigrid/envs/doorkeyoptional.py
@@ -15,7 +15,7 @@ class DoorKeyOptionalEnv(MiniGridEnv):
                  size=8,
                  key_color=None,
                  door_color='yellow',
-                 door_reward=1.0,
+                 door_reward=0.0,
                  max_steps=10*8**2,
                  seed=1337,
                  goal_reward=1,

--- a/gym_minigrid/envs/doorkeyoptional.py
+++ b/gym_minigrid/envs/doorkeyoptional.py
@@ -18,11 +18,13 @@ class DoorKeyOptionalEnv(MiniGridEnv):
                  door_reward=1.0,
                  max_steps=10*8**2,
                  seed=1337,
+                 goal_reward=1,
     ):
         self._door_reward = door_reward
         self._key_color = key_color  # must be same as door_color to solve task
         self._door_color = door_color
         self._door_num_times_opened = 0
+        self._goal_reward = goal_reward
         super().__init__(grid_size=size, max_steps=max_steps, seed=seed)
 
     def step(self, action):
@@ -103,6 +105,13 @@ class DoorKeyOptionalEnv(MiniGridEnv):
         self.put_obj(Door(self._door_color, is_locked=True), splitIdx, doorIdx)
 
         self.mission = "use the key to open the door and then get to the goal"
+
+    def _reward(self):
+        """
+        Compute the reward to be given upon success.  Overrides default
+        of 1 - 0.9 * (self.step_count / self.max_steps)
+        """
+        return self._goal_reward - 0.9 * (self.step_count / self.max_steps)
 
 
 class DoorHasKey8x8Env(DoorKeyOptionalEnv):

--- a/gym_minigrid/envs/key_to_gifts_to_door.py
+++ b/gym_minigrid/envs/key_to_gifts_to_door.py
@@ -73,6 +73,7 @@ class KeyToGiftsToDoorKeyOptional(gym.Env):
         return getattr(self.env, name)
 
     def seed(self, seed=None):
+        self._wrapper_seed = seed
         return self.env.seed(seed)
 
     def close(self):

--- a/gym_minigrid/envs/opengifts.py
+++ b/gym_minigrid/envs/opengifts.py
@@ -30,7 +30,7 @@ class GiftsEnv(MiniGridEnv):
 
         super().__init__(
             grid_size=size,
-            max_steps=5*max_steps,
+            max_steps=max_steps,
             # Set this to True for maximum speed
             see_through_walls=True,
             seed=seed

--- a/gym_minigrid/envs/opengifts.py
+++ b/gym_minigrid/envs/opengifts.py
@@ -1,3 +1,4 @@
+import numpy as np
 from gym_minigrid.minigrid import *
 from gym_minigrid.register import register
 
@@ -6,16 +7,22 @@ class GiftsEnv(MiniGridEnv):
     """
     Environment in which the agent has to open randomly 
     placed gifts
+
+    gift_reward : scalar, or list/tuple
+       if list/tuple, then a range of [min, max) specifying the reward range
+       to uniformly sample from.
     """
 
     def __init__(self,
                  size=8,
                  num_objs=3,
-                 gift_reward=10,
+                 gift_reward=10.,
                  max_steps=5*8**2,
                  seed=1337
     ):
-        self._gift_reward = gift_reward  # TODO: draw this from a Gaussian
+        if not isinstance(gift_reward, (list, tuple)):
+            self._gift_reward = [gift_reward, gift_reward]
+
         if num_objs < 1:
             raise ValueError(f"num_objs must be an integer greater than 0")
         self.num_objs = num_objs
@@ -60,7 +67,7 @@ class GiftsEnv(MiniGridEnv):
             fwd_cell = self.grid.get(*fwd_pos)
 
             if fwd_cell.type == 'gift':
-                reward += self._gift_reward
+                reward += np.random.uniform(*self._gift_reward)
                 self._num_opened += 1
                 if self._num_opened == self.num_objs:
                     done = True

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -344,7 +344,7 @@ class Gift(WorldObj):
         self.is_open = False
 
     def can_overlap(self):
-        return False
+        return True
 
     def can_pickup(self):
         return False


### PR DESCRIPTION
- allow uniform sampling from reward range for gifts
- allow agent to overlap with gifts (so don't result in any configs where agent is blocked from reaching all gifts)
- allow user to specify final reward amt for goal in 3rd phase (override default of 1-steps/max_steps)

bugfix:
- set seed for wrapper in 3phase env (so parallelized implementations that rely on `env.seed(seed)` will correctly be able to modify the starting seed for each parallel env when not calling the 3phase env constructor directly.
- remove factor multiplying max_steps in gifts env