### PR TITLE
Add option to not be done if task finished

### DIFF
--- a/gym_minigrid/envs/fetchkey.py
+++ b/gym_minigrid/envs/fetchkey.py
@@ -7,6 +7,10 @@ class KeyEnv(MiniGridEnv):
     Environment in which the agent has to fetch a key.  
     Episode ends when key is fetched, or timeout, but no reward is given in
     either case.
+
+    done_when_fetched : bool, if True, env returns done as True
+       when key is fetched.  Otherwise, done only happens at timeout
+       from reaching max_steps.
     """
 
     def __init__(self,
@@ -14,9 +18,11 @@ class KeyEnv(MiniGridEnv):
                  key_color='yellow',
                  start_by_key=False,
                  max_steps=2*8**2,
+                 done_when_fetched=False,
                  seed=1337):
         self.key_color = key_color
         self._start_by_key = start_by_key
+        self._done_when_fetched = done_when_fetched
 
         super().__init__(
             grid_size=size,
@@ -57,7 +63,9 @@ class KeyEnv(MiniGridEnv):
         if self.carrying and self.carrying.type == 'key':
             info['carrying_key_color'] = self.carrying.color
             reward = 0
-            done = True
+
+            if self._done_when_fetched:
+                done = True
 
         return obs, reward, done, info
 

--- a/gym_minigrid/envs/opengifts.py
+++ b/gym_minigrid/envs/opengifts.py
@@ -11,6 +11,10 @@ class GiftsEnv(MiniGridEnv):
     gift_reward : scalar, or list/tuple
        if list/tuple, then a range of [min, max) specifying the reward range
        to uniformly sample from.
+
+    done_when_all_opened : bool, if True, env returns done as True
+       when all gifts have been opened.  Otherwise, done only
+       happens at timeout from reaching max_steps.
     """
 
     def __init__(self,
@@ -18,6 +22,7 @@ class GiftsEnv(MiniGridEnv):
                  num_objs=3,
                  gift_reward=10.,
                  max_steps=5*8**2,
+                 done_when_all_opened=False,
                  seed=1337
     ):
         if not isinstance(gift_reward, (list, tuple)):
@@ -27,6 +32,7 @@ class GiftsEnv(MiniGridEnv):
             raise ValueError(f"num_objs must be an integer greater than 0")
         self.num_objs = num_objs
         self._num_opened = 0
+        self._done_when_all_opened = done_when_all_opened
 
         super().__init__(
             grid_size=size,
@@ -69,7 +75,7 @@ class GiftsEnv(MiniGridEnv):
             if fwd_cell.type == 'gift':
                 reward += np.random.uniform(*self._gift_reward)
                 self._num_opened += 1
-                if self._num_opened == self.num_objs:
+                if self._done_when_all_opened and self._num_opened == self.num_objs:
                     done = True
 
         return obs, reward, done, info


### PR DESCRIPTION
e.g. if agent picks up key or opens all gifts, episode used to return done as True.  In order to allow fixing episode lengths, provide the option to not end the episode if the task has been finished

flag defaults to False for both fetchkey and opengifts envs.