### PR TITLE
Goalkeyoptional

### DIFF
--- a/gym_minigrid/envs/__init__.py
+++ b/gym_minigrid/envs/__init__.py
@@ -26,3 +26,4 @@ from gym_minigrid.envs.opengifts import *
 from gym_minigrid.envs.fetchkey import *
 from gym_minigrid.envs.key_to_gifts_to_door import *
 from gym_minigrid.envs.keygoal import *
+from gym_minigrid.envs.goalkeyoptional import *

--- a/gym_minigrid/envs/goalkeyoptional.py
+++ b/gym_minigrid/envs/goalkeyoptional.py
@@ -1,0 +1,105 @@
+from gym_minigrid.minigrid import *
+from gym_minigrid.register import register
+
+
+class GoalKeyOptionalEnv(MiniGridEnv):
+    """
+    Environment in which the agent has to reach the goal.  If agent is initialized
+    already carrying a key (of any color), agent is awarded extra upon reaching the goal.
+    """
+
+    def __init__(self,
+                 size=8,
+                 key_color=None,
+                 key_reward=3,
+                 max_steps=8**2,
+                 seed=1337,
+                 goal_reward=1.,
+    ):
+        self.key_color = key_color
+        self.key_reward = key_reward
+        self.goal_reward = goal_reward
+
+        super().__init__(
+            grid_size=size,
+            max_steps=max_steps,
+            # Set this to True for maximum speed
+            see_through_walls=True,
+            seed=seed,
+        )
+
+    def reset(self):
+        """Override reset so that agent can be initialized
+        carrying a key already"""
+
+        # Current position and direction of the agent
+        self.agent_pos = None
+        self.agent_dir = None
+
+        self._gen_grid(self.width, self.height)
+
+        # Item picked up, being carried
+        if self.key_color is not None:
+            self.carrying = Key(color=self.key_color)
+        else:
+            self.carrying = None
+
+        # Step count since episode start
+        self.step_count = 0
+
+        # Return first observation
+        obs = self.gen_obs()
+        return obs
+
+    def _gen_grid(self, width, height):
+        self.grid = Grid(width, height)
+
+        # Generate the surrounding walls
+        self.grid.horz_wall(0, 0)
+        self.grid.horz_wall(0, height-1)
+        self.grid.vert_wall(0, 0)
+        self.grid.vert_wall(width-1, 0)
+
+        # Place the agent in the top-left corner
+        self.agent_pos = (1, 1)
+        self.agent_dir = 0
+
+        # Place a goal square in the bottom-right corner
+        self.put_obj(Goal(), width - 2, height - 2)
+
+        self.mission = "go to goal"
+
+    def _reward(self):
+        """
+        Compute the reward to be given upon reaching goal.  Overrides default
+        of 1 - 0.9 * (self.step_count / self.max_steps)
+        """
+        reward = self.goal_reward
+
+        if self.carrying and self.carrying.type == 'key':
+            # extra reward if carrying key at goal
+            reward += self.key_reward
+
+        return reward - 0.9 * (self.step_count / self.max_steps)
+
+
+class GoalKeyOptionalEnvNoKey6x6(GoalKeyOptionalEnv):
+    def __init__(self):
+        super().__init__(size=6, max_steps=10*6**2, key_color=None)
+
+
+class GoalKeyOptionalEnvWithKey6x6(GoalKeyOptionalEnv):
+    def __init__(self):
+        super().__init__(size=6, max_steps=10*6**2, key_color='yellow')
+
+
+register(
+    id='MiniGrid-GoalKeyOptionalEnvNoKey-6x6-v0',
+    entry_point='gym_minigrid.envs:GoalKeyOptionalEnvNoKey6x6'
+)
+
+
+register(
+    id='MiniGrid-GoalKeyOptionalEnvWithKey-6x6-v0',
+    entry_point='gym_minigrid.envs:GoalKeyOptionalEnvWithKey6x6'
+)

--- a/gym_minigrid/envs/key_to_gifts_to_door.py
+++ b/gym_minigrid/envs/key_to_gifts_to_door.py
@@ -1,3 +1,5 @@
+import warnings
+
 import gym
 from gym_minigrid.register import register
 
@@ -34,14 +36,17 @@ class KeyToGiftsToDoorKeyOptional(gym.Env):
         self.reward_range = self.env.reward_range
         self.metadata = self.env.metadata
 
+        if 'key_color' in self._env_kwargs[-1]:
+            warnings.warn("'key_color' should not be provided in kwargs for last env")
+            # Remove key_color since it should only be set based on whether
+            # the agent picked up the key in the first environment
+            self._env_kwargs[-1].pop('key_color')
+
     def reset(self):
         """reset returns agent back to first environment, KeyEnv"""
         self._env_idx = 0
         self._wrapper_seed += 1
-        self.env = self._envs[self._env_idx](
-            **self._env_kwargs[self._env_idx],
-            seed=self._wrapper_seed
-        )
+        self.env = self._envs[0](**self._env_kwargs[0], seed=self._wrapper_seed)
         observation = self.env.reset()
         return observation
 


### PR DESCRIPTION
- create new env where agent has to reach goal, but can be initialized carrying a key (and rewarded extra points upon reaching goal if carrying key) -- to be used as final env in 3phase env experiments (easier to solve than doorkeyoptional)
