### PR TITLE
Generalize multiphase carrying_key to carrying

### DIFF
--- a/gym_minigrid/envs/doorkeyoptional.py
+++ b/gym_minigrid/envs/doorkeyoptional.py
@@ -7,13 +7,13 @@ class DoorKeyOptionalEnv(MiniGridEnv):
     Environment with a yellow door and no key, sparse reward.  Agent
     must unlock door to reach goal.
 
-    Agent cannot solve task unless it is already carrying a yellow key 
-    when the environment is initialized.
+    Agent cannot solve task unless it is already carrying a key matching 
+    the color of the door when the environment is initialized.
     """
 
     def __init__(self,
                  size=8,
-                 key_color=None,
+                 carrying=None,
                  door_color='yellow',
                  door_reward=0.0,
                  max_steps=10*8**2,
@@ -21,7 +21,7 @@ class DoorKeyOptionalEnv(MiniGridEnv):
                  goal_reward=1,
     ):
         self._door_reward = door_reward
-        self._key_color = key_color  # must be same as door_color to solve task
+        self._carrying = carrying  # key must be same color as door to solve task
         self._door_color = door_color
         self._door_num_times_opened = 0
         self._goal_reward = goal_reward
@@ -67,10 +67,7 @@ class DoorKeyOptionalEnv(MiniGridEnv):
         assert start_cell is None or start_cell.can_overlap()
 
         # Item picked up, being carried
-        if self._key_color is not None:
-            self.carrying = Key(color=self._key_color)
-        else:
-            self.carrying = None
+        self.carrying = self._carrying
 
         # Step count since episode start
         self.step_count = 0
@@ -116,12 +113,12 @@ class DoorKeyOptionalEnv(MiniGridEnv):
 
 class DoorHasKey8x8Env(DoorKeyOptionalEnv):
     def __init__(self):
-        super().__init__(size=8, key_color='yellow', door_color='yellow')
+        super().__init__(size=8, carrying=Key('yellow'), door_color='yellow')
 
 
 class DoorNoKey8x8Env(DoorKeyOptionalEnv):
     def __init__(self):
-        super().__init__(size=8, key_color=None)
+        super().__init__(size=8, carrying=None)
 
 
 register(

--- a/gym_minigrid/envs/goalkeyoptional.py
+++ b/gym_minigrid/envs/goalkeyoptional.py
@@ -10,13 +10,13 @@ class GoalKeyOptionalEnv(MiniGridEnv):
 
     def __init__(self,
                  size=8,
-                 key_color=None,
+                 carrying=None,
                  key_reward=3,
                  max_steps=8**2,
                  seed=1337,
                  goal_reward=1.,
     ):
-        self.key_color = key_color
+        self._carrying = carrying
         self.key_reward = key_reward
         self.goal_reward = goal_reward
 
@@ -39,10 +39,7 @@ class GoalKeyOptionalEnv(MiniGridEnv):
         self._gen_grid(self.width, self.height)
 
         # Item picked up, being carried
-        if self.key_color is not None:
-            self.carrying = Key(color=self.key_color)
-        else:
-            self.carrying = None
+        self.carrying = self._carrying
 
         # Step count since episode start
         self.step_count = 0
@@ -85,12 +82,12 @@ class GoalKeyOptionalEnv(MiniGridEnv):
 
 class GoalKeyOptionalEnvNoKey6x6(GoalKeyOptionalEnv):
     def __init__(self):
-        super().__init__(size=6, max_steps=10*6**2, key_color=None)
+        super().__init__(size=6, max_steps=10*6**2, carrying=None)
 
 
 class GoalKeyOptionalEnvWithKey6x6(GoalKeyOptionalEnv):
     def __init__(self):
-        super().__init__(size=6, max_steps=10*6**2, key_color='yellow')
+        super().__init__(size=6, max_steps=10*6**2, carrying=Key('yellow'))
 
 
 register(

--- a/gym_minigrid/envs/opengifts.py
+++ b/gym_minigrid/envs/opengifts.py
@@ -5,8 +5,8 @@ from gym_minigrid.register import register
 
 class GiftsEnv(MiniGridEnv):
     """
-    Environment in which the agent has to open randomly 
-    placed gifts
+    Environment in which the agent has to open randomly placed gifts.
+    The agent can be optionally initialized already carrying an object.
 
     gift_reward : scalar, or list/tuple
        if list/tuple, then a range of [min, max) specifying the reward range
@@ -15,6 +15,8 @@ class GiftsEnv(MiniGridEnv):
     done_when_all_opened : bool, if True, env returns done as True
        when all gifts have been opened.  Otherwise, done only
        happens at timeout from reaching max_steps.
+
+    carrying : a WorldObject subclass, e.g. a Key
     """
 
     def __init__(self,
@@ -23,6 +25,7 @@ class GiftsEnv(MiniGridEnv):
                  gift_reward=10.,
                  max_steps=5*8**2,
                  done_when_all_opened=False,
+                 carrying=None,
                  seed=1337
     ):
         if not isinstance(gift_reward, (list, tuple)):
@@ -35,6 +38,7 @@ class GiftsEnv(MiniGridEnv):
         self.num_objs = num_objs
         self._num_opened = 0
         self._done_when_all_opened = done_when_all_opened
+        self._carrying = carrying
 
         super().__init__(
             grid_size=size,
@@ -100,8 +104,8 @@ class GiftsEnv(MiniGridEnv):
         start_cell = self.grid.get(*self.agent_pos)
         assert start_cell is None or start_cell.can_overlap()
 
-        # Item picked up, being carried, initially nothing
-        self.carrying = None
+        # Item picked up, being carried
+        self.carrying = self._carrying
 
         # Step count since episode start
         self.step_count = 0


### PR DESCRIPTION
Don't just initialize agent with key in last phase, instead, initialize it in the next phase with whatever it's carrying in the previous phase.

New implication for distractor phase is that in the distractor phase, the agent will know whether it picked up a key in the 1st phase.