### PR TITLE
Threephase

### DIFF
--- a/gym_minigrid/envs/delayed_reward_multiphase.py
+++ b/gym_minigrid/envs/delayed_reward_multiphase.py
@@ -80,7 +80,7 @@ class ThreePhaseDelayedReward(gym.Env):
             if self._env_idx == 0 and self.key_teleports_to_end_only:
                 # Initialize agent in the final phase with the same carrying status as in phase 1
                 self._env_kwargs[-1]['carrying'] = self.carrying
-            else:
+            elif not self.key_teleports_to_end_only:
                 # If agent finished the current phase while carrying an object,
                 # then initialize it in next phase carrying the same object
                 self._env_kwargs[self._env_idx + 1]['carrying'] = self.carrying

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='gym_minigrid',
-    version='1.0.8',
+    version='1.0.9',
     keywords='memory, environment, agent, rl, openaigym, openai-gym, gym',
     url='https://github.com/maximecb/gym-minigrid',
     description='Minimalistic gridworld package for OpenAI Gym',


### PR DESCRIPTION
Bugfix -- even if agent picked up key in first phase, it was not corectly initialized w/ it in 3rd phase with teleport option because if-else was overwriting the last phase carrying status in the intermediate phase.